### PR TITLE
Better parsing of action types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,9 @@ export function createAtomic<s, t>(reducerName: string, initialState: s, reducer
     params: any[],
     actionName: string
   ): AtomicAction<s, t> {
+    if (!funcExistsInReducer(reducerFuncs, actionName)) {
+      throw `Wrap error! ${actionName} cannot be found. Did you remember to pass it to 'createAtomic()'?`;
+    }
     return {
       type: generateKey(reducerName, actionName),
       payload: stripUndefined(params)
@@ -77,4 +80,8 @@ export function createAtomic<s, t>(reducerName: string, initialState: s, reducer
 
 export const parseActionKeyFromType = (reducerName: string, actionType: string): string => {
   return actionType.includes(reducerName + "_") ? actionType.substr(actionType.indexOf("_") + 1) : "";
+};
+
+const funcExistsInReducer = (reducerFuncs: {}, actionName): boolean => {
+  return Object.keys(reducerFuncs).filter(x => x === actionName).length > 0;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export function createAtomic<s, t>(reducerName: string, initialState: s, reducer
   function reducer(state: s, action: AtomicAction<s, t>): s | t {
     const thisState = state || initialState;
     const params = action && action.payload ? action.payload : [];
-    const funcKey = parseActionKeyFromType(action.type);
+    const funcKey = parseActionKeyFromType(reducerName, action.type);
     const func = funcKey in reducerFuncs ? reducerFuncs[funcKey] : false;
     return !func || !func(...params) ? thisState : func(...params)(thisState);
   }
@@ -70,11 +70,11 @@ export function createAtomic<s, t>(reducerName: string, initialState: s, reducer
     }, {});
   }
 
-  function parseActionKeyFromType(actionType: string): string {
-    return actionType.includes(reducerName) ? actionType.substr(actionType.indexOf("_") + 1) : "";
-  }
-
   function generateKey(reducerName: string, actionName: string): string {
     return reducerName + "_" + actionName;
   }
 }
+
+export const parseActionKeyFromType = (reducerName: string, actionType: string): string => {
+  return actionType.includes(reducerName + "_") ? actionType.substr(actionType.indexOf("_") + 1) : "";
+};

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { createStore, combineReducers } from "redux";
-import { AtomicAction, createAtomic } from "../index";
+import { AtomicAction, createAtomic, parseActionKeyFromType } from "../index";
 
 interface AtomicState {
   title: string;
@@ -159,5 +159,11 @@ describe("It responds to actions", () => {
       string: "",
       number: 1
     });
+  });
+});
+
+describe("It does not confuse reducers", () => {
+  it("Does not confuse user_hello and userAdvanced_hello", () => {
+    expect(parseActionKeyFromType("user", "userAdvanced_hello")).toEqual("");
   });
 });

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -167,3 +167,10 @@ describe("It does not confuse reducers", () => {
     expect(parseActionKeyFromType("user", "userAdvanced_hello")).toEqual("");
   });
 });
+
+describe("It does not create actions for non-existant functions", () => {
+  it("Does not allow a 'two' action function to be created", () => {
+    const { wrap, reducer } = createAtomic("boo", initialState, [one]);
+    expect(wrap(two)).toThrowError();
+  });
+});


### PR DESCRIPTION
* Fixed an error where actions of `user` and `userExtended` reducers would mess with one another
* Now throws exception when trying to wrap function that has not been included.