### PR TITLE
Throw error on nameless function and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,9 @@ import { createReducer } from 'redux-atomic'
 
 const initialState: number = 0;
 
-function inc(howMuch: number) {
-    return (state: number): number => state + howMuch
-}
+const inc = (howMuch: number) => (state: number): number => state + howMuch
 
-function dec(howMuch: number) {
-    return (state: number): number => state - howMuch
-}
+const dec = (howMuch: number) => (state: number): number => state - howMuch
 
 const { reducer, wrap } = createReducer("niceReducer", initialState, [inc, dec])
 
@@ -184,12 +180,12 @@ Yeah sure, the auto generated actions have the format:
 Therefore in a reducer called `niceReducer`, with a function like:
 
 ```typescript
-function newTitle(newTitle: string) {
-  return (state: State): State => ({
+const newTitle = (newTitle: string) => (state: State): State => {
+  return {
     ...state,
     title: newTitle
-  });
-}
+  };
+};
 ```
 
 ...called like this:
@@ -212,10 +208,6 @@ This would then be picked up by the `newTitle` function passed into the reducer.
 ### Anything else?
 
 Building your reducers in this way means you can have multiple instances of them that don't interact with one another, so long as they are given different names and each set of actions are exported with the matching `wrap()` function.
-
-### Why `function` and not `const` in the examples?
-
-The library uses `function.name` to name the actions, anonymous functions lose their name when imported from other files, this way you don't need to specifically name each action.
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,13 @@ import { createReducer } from 'redux-atomic'
 
 const initialState: number = 0;
 
-const inc = (howMuch: number) => (state: number): number => state + howMuch
+function inc(howMuch: number) {
+    return (state: number): number => state + howMuch
+}
 
-const dec = (howMuch: number) => (state: number): number => state - howMuch
+function dec(howMuch: number) {
+    return (state: number): number => state - howMuch
+}
 
 const { reducer, wrap } = createReducer("niceReducer", initialState, [inc, dec])
 
@@ -180,12 +184,12 @@ Yeah sure, the auto generated actions have the format:
 Therefore in a reducer called `niceReducer`, with a function like:
 
 ```typescript
-const newTitle = (newTitle: string) => (state: State): State => {
-  return {
+function newTitle(newTitle: string) {
+  return (state: State): State => ({
     ...state,
     title: newTitle
-  };
-};
+  });
+}
 ```
 
 ...called like this:
@@ -208,6 +212,10 @@ This would then be picked up by the `newTitle` function passed into the reducer.
 ### Anything else?
 
 Building your reducers in this way means you can have multiple instances of them that don't interact with one another, so long as they are given different names and each set of actions are exported with the matching `wrap()` function.
+
+### Why `function` and not `const` in the examples?
+
+The library uses `function.name` to name the actions, anonymous functions lose their name when imported from other files.
 
 ### Testing
 
@@ -241,7 +249,11 @@ Testing the outcome of a series of actions is as simple as composing them togeth
 import { compose } from "ramda";
 
 const initialState = { title: "blah", number: 0 };
-const bunchOfActions = compose(increment(10), decrement(20), rename("Dog"));
+const bunchOfActions = compose(
+  increment(10),
+  decrement(20),
+  rename("Dog")
+);
 const expected = { title: "Dog", number: -10 };
 
 expect(bunchOfActions(initialState)).toEqual(expected);

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Building your reducers in this way means you can have multiple instances of them
 
 ### Why `function` and not `const` in the examples?
 
-The library uses `function.name` to name the actions, anonymous functions lose their name when imported from other files.
+The library uses `function.name` to name the actions, anonymous functions lose their name when imported from other files, this way you don't need to specifically name each action.
 
 ### Testing
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,15 @@ export function createAtomic<s, t>(reducerName: string, initialState: s, reducer
   }
 }
 
+export const getFunctionName = <s, t>(func: GenericAction<s, t>): string => {
+  const name = func.name;
+  if (name.length < 1) {
+    throw "Cannot ascertain name of imported functions, please use `function` type instead";
+  } else {
+    return name;
+  }
+};
+
 export const parseActionKeyFromType = (reducerName: string, actionType: string): string => {
   return actionType.includes(reducerName + "_") ? actionType.substr(actionType.lastIndexOf("_") + 1) : "";
 };

--- a/src/tests/function.ts
+++ b/src/tests/function.ts
@@ -1,0 +1,7 @@
+export function niceFunction() {
+  return "nice";
+}
+
+export const ohNo = () => {
+  return "what";
+};

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,5 +1,5 @@
 import { createStore, combineReducers } from "redux";
-import { AtomicAction, createAtomic, parseActionKeyFromType, getFunctionName } from "../index";
+import { createAtomic, parseActionKeyFromType } from "../index";
 import { niceFunction, ohNo } from "./function";
 interface AtomicState {
   title: string;
@@ -181,16 +181,18 @@ describe("It does not create actions for non-existant functions", () => {
 describe("It names a function", () => {
   it("Gets a local function name", () => {
     const localFunction: any = () => "horse";
-    expect(getFunctionName(localFunction)).toEqual("localFunction");
+    const { actionTypes } = createAtomic("boo", initialState, [localFunction]);
+    expect(actionTypes).toEqual(["boo_localFunction"]);
   });
 
   it("Gets an imported function name", () => {
-    expect(getFunctionName(niceFunction as any)).toEqual("niceFunction");
+    const { actionTypes } = createAtomic("boo", initialState, [niceFunction as any]);
+    expect(actionTypes).toEqual(["boo_niceFunction"]);
   });
 
   it("Throws an error when sent an anonymous function", () => {
     try {
-      expect(getFunctionName(ohNo as any)).toThrow();
+      expect(createAtomic("boo", initialState, [ohNo as any])).toThrowError();
     } catch {}
   });
 });

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { createStore, combineReducers } from "redux";
-import { AtomicAction, createAtomic, parseActionKeyFromType } from "../index";
-
+import { AtomicAction, createAtomic, parseActionKeyFromType, getFunctionName } from "../index";
+import { niceFunction, ohNo } from "./function";
 interface AtomicState {
   title: string;
   arrayOfStrings: string[];
@@ -175,5 +175,22 @@ describe("It does not create actions for non-existant functions", () => {
   it("Does not allow a 'two' action function to be created", () => {
     const { wrap, reducer } = createAtomic("boo", initialState, [one]);
     expect(wrap(two)).toThrowError();
+  });
+});
+
+describe("It names a function", () => {
+  it("Gets a local function name", () => {
+    const localFunction: any = () => "horse";
+    expect(getFunctionName(localFunction)).toEqual("localFunction");
+  });
+
+  it("Gets an imported function name", () => {
+    expect(getFunctionName(niceFunction as any)).toEqual("niceFunction");
+  });
+
+  it("Throws an error when sent an anonymous function", () => {
+    try {
+      expect(getFunctionName(ohNo as any)).toThrow();
+    } catch {}
   });
 });

--- a/yarn-error.log
+++ b/yarn-error.log
@@ -2,7 +2,7 @@ Arguments:
   /usr/local/bin/node /usr/local/bin/yarn test
 
 PATH: 
-  /Users/dhar/.local/bin:/Users/dhar/.opam/system/bin:/Users/dhar/Helpers/Scripts:/usr/local/opt/nvm/:/Users/dhar/.nvm/:/Users/dhar/.nvm:/usr/local/share/dotnet/:/Applications/Sublime Text.app/Contents/SharedSupport/bin:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/bin:/Users/dhar/Library/Android/sdk//platform-tools:/Users/dhar/Library/Android/sdk//tools:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/share/dotnet:/Library/Frameworks/Mono.framework/Versions/Current/Commands:./node_modules/.bin
+  /Users/dhar/.psvm/current/bin:/Users/dhar/.local/bin:/Users/dhar/.opam/system/bin:/Users/dhar/Helpers/Scripts:/usr/local/opt/nvm/:/Users/dhar/.nvm/:/Users/dhar/.nvm:/usr/local/share/dotnet/:/Applications/Sublime Text.app/Contents/SharedSupport/bin:/Applications/Visual Studio Code.app/Contents/Resources/app/bin:/Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/bin:/Users/dhar/Library/Android/sdk//platform-tools:/Users/dhar/Library/Android/sdk//tools:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/share/dotnet:/Library/Frameworks/Mono.framework/Versions/Current/Commands:./node_modules/.bin
 
 Yarn version: 
   1.5.1
@@ -16,7 +16,7 @@ Platform:
 npm manifest: 
   {
     "name": "redux-atomic",
-    "version": "0.0.12",
+    "version": "0.1.4",
     "description": "A nice new way to do actions",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",


### PR DESCRIPTION
As per error #14 , throw error when functions end up with no name.