### PR TITLE
Warn when multiple reducers with the same name are used.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,9 +20,11 @@ export type g4<s, t, A, B, C, D> = (a: A, b: B, c: C, d: D) => AtomicAction<s, t
 
 export type GenericAction<s, t> = (...a: any[]) => AtomicReducerFunc<s, t>;
 
+let allNames = [];
+
 export function createAtomic<s, t>(reducerName: string, initialState: s, reducers: GenericAction<s, t>[]) {
   const reducerFuncs = saveReducerFuncs(reducers);
-
+  checkExistingName(reducerName);
   return {
     reducer,
     wrap: wrapper,
@@ -81,6 +83,7 @@ export function createAtomic<s, t>(reducerName: string, initialState: s, reducer
   function generateKey(reducerName: string, actionName: string): string {
     return reducerName + "_" + actionName;
   }
+
   function getFunctionName<s, t>(func: GenericAction<s, t>, index: number, length: number): string {
     const name = func.name;
     if (name.length < 1) {
@@ -89,6 +92,13 @@ export function createAtomic<s, t>(reducerName: string, initialState: s, reducer
     } else {
       return name;
     }
+  }
+
+  function checkExistingName(reducerName: string) {
+    if (allNames.includes(reducerName)) {
+      throw `Redux Atomic: Error in createAtomic for ${reducerName}! A reducer with this name already exists!`;
+    }
+    allNames.push(reducerName);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,9 @@ export type g4<s, t, A, B, C, D> = (a: A, b: B, c: C, d: D) => AtomicAction<s, t
 
 export type GenericAction<s, t> = (...a: any[]) => AtomicReducerFunc<s, t>;
 
+// please forgive this mutable state
+// it records all reducer names to avoid duplicates
+// and the weird errors that result
 let allNames = [];
 
 export function createAtomic<s, t>(reducerName: string, initialState: s, reducers: GenericAction<s, t>[]) {

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,6 +1,7 @@
 import { createStore, combineReducers } from "redux";
 import { createAtomic, parseActionKeyFromType } from "../index";
 import { niceFunction, ohNo } from "./function";
+
 interface AtomicState {
   title: string;
   arrayOfStrings: string[];

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -181,18 +181,34 @@ describe("It does not create actions for non-existant functions", () => {
 describe("It names a function", () => {
   it("Gets a local function name", () => {
     const localFunction: any = () => "horse";
-    const { actionTypes } = createAtomic("boo", initialState, [localFunction]);
-    expect(actionTypes).toEqual(["boo_localFunction"]);
+    const { actionTypes } = createAtomic("boo2", initialState, [localFunction]);
+    expect(actionTypes).toEqual(["boo2_localFunction"]);
   });
 
   it("Gets an imported function name", () => {
-    const { actionTypes } = createAtomic("boo", initialState, [niceFunction as any]);
-    expect(actionTypes).toEqual(["boo_niceFunction"]);
+    const { actionTypes } = createAtomic("boo3", initialState, [niceFunction as any]);
+    expect(actionTypes).toEqual(["boo3_niceFunction"]);
   });
 
   it("Throws an error when sent an anonymous function", () => {
     try {
-      expect(createAtomic("boo", initialState, [ohNo as any])).toThrowError();
-    } catch {}
+      createAtomic("boo", initialState, [ohNo as any]);
+      expect(true).toBeTruthy();
+    } catch {
+      expect.assertions(0);
+    }
+  });
+});
+
+describe("It spots multiple reducers with same name", () => {
+  it("Throws an error", () => {
+    const localFunction: any = () => "horse";
+    const { actionTypes } = createAtomic("wooo", initialState, [localFunction as any]);
+    try {
+      expect(createAtomic("wooo", initialState, [niceFunction as any])).toThrowError();
+      expect(true).toBeTruthy();
+    } catch {
+      expect.assertions(0);
+    }
   });
 });


### PR DESCRIPTION
As per issue #7 