### PR TITLE
Function name in wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,11 +234,13 @@ const { actionTypes } = createAtomic("hello", state, [great, job, nice, function
 // actionTypes == ['hello_great', 'hello_job', 'hello_nice', 'hello_functions']
 ```
 
-#### `wrap(reducerFunction)`
+#### `wrap(reducerFunction, actionName)`
 
 ##### Parameters:
 
 `reducerFunction` is the reducer action you wish to wrap and turn into a dispatchable action. It must take some number of parameters, and returns a function which turns state into new state.
+
+`actionName` is optional - you will only need to provide it if the function is a const function imported from another file so we cannot work it out automatically. It should match the name you passed to `createAtomic`, and will throw an error if not.
 
 ##### Returns:
 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,10 @@ The array shape will work for types of `Function` or anonymous lambda functions 
 
 As Redux Atomic creates regular Flux actions under the hood, having two reducers with the same names means they will both pick up some of the same functions and things can quickly get messy and quite confusing. This error will be thrown if you try and do this.
 
+#### `Redux Atomic: Error in wrap for niceReducer! Could not wrap function greatFunction as it has not been passed to createAtomic();`;
+
+This is to make sure we don't end up with names not matching between passing to createAtomic() and wrap(). If this occurs - check you've sent the function you intend to wrap and any passed names match.
+
 ### Anything else?
 
 Building your reducers in this way means you can have multiple instances of them that don't interact with one another, so long as they are given different names and each set of actions are exported with the matching `wrap()` function.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-atomic",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "A nice new way to do actions",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,9 +76,19 @@ export function createAtomic<s, t>(reducerName: string, initialState: s, reducer
   function wrapper<s, t, A, B, C>(func: f3<s, t, A, B, C>, actionName?: string): g3<s, t, A, B, C>;
   function wrapper<s, t, A, B, C, D>(func: f4<s, t, A, B, C, D>, actionName?: string): g4<s, t, A, B, C, D> {
     const funcName = getActionName(func, actionName);
+    checkActionNameExists(funcName);
     return function(a: A, b: B, c: C, d: D) {
       return wrapStateFunc(func(a, b, c, d), [a, b, c, d], funcName);
     };
+  }
+
+  function checkActionNameExists(funcName: string) {
+    if (!isActionNameFound(funcName)) {
+      throw `Redux Atomic: Error in wrap for ${reducerName}! Could not wrap function ${funcName} as it has not been passed to createAtomic();`;
+    }
+  }
+  function isActionNameFound(funcName: string) {
+    return Object.keys(reducerFuncs).some((key: string) => key === funcName);
   }
 
   function getActionName(func, actionName?: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,14 +66,25 @@ export function createAtomic<s, t>(reducerName: string, initialState: s, reducer
     }, []);
   }
 
-  function wrapper<s, t>(func: f<s, t>): g<s, t>;
-  function wrapper<s, t, A>(func: f1<s, t, A>): g1<s, t, A>;
-  function wrapper<s, t, A, B>(func: f2<s, t, A, B>): g2<s, t, A, B>;
-  function wrapper<s, t, A, B, C>(func: f3<s, t, A, B, C>): g3<s, t, A, B, C>;
-  function wrapper<s, t, A, B, C, D>(func: f4<s, t, A, B, C, D>): g4<s, t, A, B, C, D> {
+  function wrapper<s, t>(func: f<s, t>, actionName?: string): g<s, t>;
+  function wrapper<s, t, A>(func: f1<s, t, A>, actionName?: string): g1<s, t, A>;
+  function wrapper<s, t, A, B>(func: f2<s, t, A, B>, actionName?: string): g2<s, t, A, B>;
+  function wrapper<s, t, A, B, C>(func: f3<s, t, A, B, C>, actionName?: string): g3<s, t, A, B, C>;
+  function wrapper<s, t, A, B, C, D>(func: f4<s, t, A, B, C, D>, actionName?: string): g4<s, t, A, B, C, D> {
     return function(a: A, b: B, c: C, d: D) {
-      return wrapStateFunc(func(a, b, c, d), [a, b, c, d], func.name);
+      return wrapStateFunc(func(a, b, c, d), [a, b, c, d], getActionName(func, actionName));
     };
+  }
+
+  function getActionName(func, actionName?: string) {
+    const name = func.name;
+    if (name.length > 0) {
+      return name;
+    }
+    if (actionName.length > 0) {
+      return actionName;
+    }
+    throw `Redux Atomic: Error in wrap for ${reducerName}! Could not ascertain name of function - if you are using imported const functions please provide an explicit name to wrap, ie wrap(function, 'functionName')`;
   }
 
   function saveReducerFuncs(reducers: GenericAction<s, t>[]) {

--- a/src/tests/function.ts
+++ b/src/tests/function.ts
@@ -2,6 +2,6 @@ export function niceFunction() {
   return "nice";
 }
 
-export const ohNo = () => {
+export const ohNo = () => () => {
   return "what";
 };

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -201,22 +201,35 @@ describe("It names a function", () => {
   });
 
   it("Does not throws an error when sent an anonymous function but is named", () => {
-    const { actionTypes } = createAtomic("boo5", initialState, [
+    const { actionTypes, reducer } = createAtomic("boo5", initialState, [
       niceFunction as any,
       { name: "ohNo", func: ohNo as any }
     ]);
+    const boo5Reducer = reducer;
     const action = {
       type: "boo5_ohNo",
       payload: []
     };
     expect(actionTypes).toEqual(["boo5_niceFunction", "boo5_ohNo"]);
     // and it still works...
-    expect(reducer(initialState, action)).toEqual("what");
+    expect(boo5Reducer(initialState, action)).toEqual("what");
   });
 
-  it.only("Throws an error when total nonsense is sent instead of a function", () => {
+  it("Throws an error when total nonsense is sent instead of a function", () => {
     try {
       createAtomic("boo6", initialState, ["nonsense"] as any);
+      expect(true).toBeTruthy();
+    } catch {
+      expect.assertions(0);
+    }
+  });
+});
+
+describe("Names in wrap", () => {
+  it("Errors on finding anonymous function", () => {
+    const { wrap } = createAtomic("boo7", initialState, [{ name: "ohNo", func: ohNo as any }]);
+    try {
+      wrap(ohNo);
       expect(true).toBeTruthy();
     } catch {
       expect.assertions(0);

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -235,6 +235,23 @@ describe("Names in wrap", () => {
       expect.assertions(0);
     }
   });
+
+  it("Doesn't errors when using named anonymous function", () => {
+    const { wrap } = createAtomic("boo8", initialState, [{ name: "ohNo", func: ohNo as any }]);
+
+    wrap(ohNo, "ohNo");
+    expect(true).toBeTruthy();
+  });
+
+  it.only("Errors when using a name that has not been used in the reducer", () => {
+    const { wrap } = createAtomic("boo9", initialState, [{ name: "ohNo", func: ohNo as any }]);
+    try {
+      wrap(ohNo, "ohNo2");
+      expect(true).toBeTruthy();
+    } catch {
+      expect.assertions(0);
+    }
+  });
 });
 
 describe("It spots multiple reducers with same name", () => {


### PR DESCRIPTION
Allow a name to be passed to `wrap()` so we can use anonymous functions if we like.